### PR TITLE
Upgrade to 0.81 of akka-persistence-cassandra

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Version {
   object Akka {
     final val AkkaVersion: String                     = "2.5.9"
     final val AkkaHttpVersion: String                 = "10.0.11"
-    final val AkkaPersistenceCassandraVersion: String = "0.80"
+    final val AkkaPersistenceCassandraVersion: String = "0.81"
   }
 
   object JsonMarshalling {


### PR DESCRIPTION
Contains fix for snapshot for latest event causing tag pid sequence numbers to reset